### PR TITLE
Adds tests for search 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import os
 from pytest import fixture
-import requests
+
+
+class MockResponse:
+    def __init__(self, text):
+        self.text = text
 
 
 def mock_pip_html():
@@ -13,9 +17,9 @@ def mock_pip_html():
         return f.read()
 
 
-# avoid spamming pip with requests, monkeypatch requests such it does not actually perform
-# a lookup but is given the mock_pip_html
+# avoid spamming pip with requests, monkeypatch requests such it
+# does not actually perform a lookup but is given the mock_pip_html
 @fixture(autouse=True)
 def patch_requests(monkeypatch):
-    monkeypatch.setattr("requests.models.Response.text", mock_pip_html())
-    monkeypatch.setattr("requests.get", lambda x: requests.Response())
+    text = mock_pip_html()
+    monkeypatch.setattr("requests.get", lambda x: MockResponse(text))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def mock_pip_html():
 
 # avoid spamming pip with requests, monkeypatch requests such it
 # does not actually perform a lookup but is given the mock_pip_html
-@fixture(autouse=True)
+@fixture
 def patch_requests(monkeypatch):
     text = mock_pip_html()
     monkeypatch.setattr("requests.get", lambda x: MockResponse(text))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+from pytest import fixture
+import requests
+
+
+def mock_pip_html():
+    """canonical html example taken from pypi
+
+    :return: string containing the html document
+    """
+    data_dir = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(data_dir, 'result_page.html'), 'r') as f:
+        return f.read()
+
+
+# avoid spamming pip with requests, monkeypatch requests such it does not actually perform
+# a lookup but is given the mock_pip_html
+@fixture(autouse=True)
+def patch_requests(monkeypatch):
+    monkeypatch.setattr("requests.models.Response.text", mock_pip_html())
+    monkeypatch.setattr("requests.get", lambda x: requests.Response())

--- a/tests/result_page.html
+++ b/tests/result_page.html
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+  <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+    <head>
+    </head>
+    <body>
+     
+<table class="list">
+<tr>
+ <th>Package</th>
+ <th><u title="Occurrence of search term weighted by field (name, summary, keywords, description, author, maintainer)">Weight*</u></th>
+ <th>Description</th>
+</tr>
+
+<tr class="odd">
+ <td><a href="/pypi/morepath-batching/0.1">morepath-batching&nbsp;0.1</a></td>
+ <td>10</td>
+ <td>A demo app for Morepath with record batching</td>
+</tr>
+<tr class="even">
+ <td><a href="/pypi/path/0.33">path&nbsp;0.33</a></td>
+ <td>10</td>
+ <td>PATH programming language</td>
+</tr>
+<tr class="odd">
+ <td><a href="/pypi/adaptpath/0.3.7">adaptpath&nbsp;0.3.7</a></td>
+ <td>9</td>
+ <td>convinent script to adapt python's sys.path</td>
+</tr>
+<tr class="even">
+ <td><a href="/pypi/adduserpath/0.4.0">adduserpath&nbsp;0.4.0</a></td>
+ <td>9</td>
+ <td>Cross-platform tool for adding locations to the user PATH, no sudo/runas required!</td>
+</tr>
+<tr class="odd">
+ <td><a href="/pypi/batchpath/0.2">batchpath&nbsp;0.2</a></td>
+ <td>9</td>
+ <td>Developer utility to generate and verify pathnames</td>
+</tr>
+<tr class="even">
+ <td><a href="/pypi/collective.pathtouid/0.1.0a">collective.pathtouid&nbsp;0.1.0a</a></td>
+ <td>9</td>
+ <td>Plone utility to change relative or absolute path inside text to UID (and resolveuid)</td>
+</tr>
+<tr class="odd">
+ <td><a href="/pypi/dirpath/0.0.24">dirpath&nbsp;0.0.24</a></td>
+ <td>9</td>
+ <td>dirpath(path) function - get path directory</td>
+</tr>
+<tr class="even">
+ <td><a href="/pypi/django-path2css/0.2.2">django-path2css&nbsp;0.2.2</a></td>
+ <td>9</td>
+ <td>Convert a request.path ('/a/b/c/d/') into CSS class names</td>
+</tr>
+<tr class="odd">
+ <td><a href="/pypi/edpath/0.1.4">edpath&nbsp;0.1.4</a></td>
+ <td>9</td>
+ <td>MS Windows command-line script to view and edit PATH-like environment variables.</td>
+</tr>
+<tr class="even">
+ <td><a href="/pypi/entrydir_pypath/0.1.0.dev3">entrydir_pypath&nbsp;0.1.0.dev3</a></td>
+ <td>9</td>
+ <td>Utility to set up sys.path for source-tree imports</td>
+</tr>
+<tr>
+ <td id="last" colspan="3"/>
+</tr>
+</table>
+    </body>
+  </html>
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,12 @@
+def test_search():
+    from pipsearch.api import search
+    a = search('path', 2)
+    expected = [
+        {'description': 'A demo app for Morepath with record batching',
+         'link': 'https://pypi.python.org/pypi/morepath-batching/0.1',
+         'name': 'morepath-batching 0.1', 'weight': 10},
+        {'description': 'PATH programming language',
+         'link': 'https://pypi.python.org/pypi/path/0.33',
+         'name': 'path 0.33', 'weight': 10}
+    ]
+    assert a == expected

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-def test_search():
+def test_search(patch_requests):
     from pipsearch.api import search
     a = search('path', 2)
     expected = [


### PR DESCRIPTION
This addition adds basic testing for ``api.search``.
I have used py.test since I have seen that it was mentioned in the `setup.py`.
I have explicitley tried to avoid to fetch a page from pypi since it would be spammy and it would make the tests reliant on pypi being up.

